### PR TITLE
Update fetch URLs to use BASE_URL

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+BASE_URL=https://launchpad.thealphahub.fun

--- a/beta/chill-baby.html
+++ b/beta/chill-baby.html
@@ -8,6 +8,7 @@
     <meta property="og:image" content="https://oaidalleapiprodscus.blob.core.windows.net/private/org-uhsM3TYEzcdSzxVlMcJvWVLc/user-zhodxV6oh21CHK1l5bjJMX8f/img-tUZn3Ez2M10YSBHFHb1YH1bN.png?st=2025-06-03T17%3A32%3A37Z&se=2025-06-03T19%3A32%3A37Z&sp=r&sv=2024-08-04&sr=b&rscd=inline&rsct=image/png&skoid=cc612491-d948-4d2e-9821-2683df3719f5&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2025-06-02T19%3A50%3A56Z&ske=2025-06-03T19%3A50%3A56Z&sks=b&skv=2024-08-04&sig=fFTyw38o679gkjgS7nI8w9aIiI3YE9cT6Of1XGyTi8c%3D" />
     <meta property="og:description" content="A new memecoin launched from Alpha Hub 🚀" />
     <title>Chill Baby ($CHILLF)</title>
+    <script src="/env.js"></script>
     <script src="/socket.io/socket.io.js"></script>
     <style>
       body {
@@ -184,7 +185,7 @@
             message,
             signature: Array.from(signedMessage.signature),
           };
-          const res = await fetch("http://localhost:3001/claim", {
+          const res = await fetch(window.BASE_URL + "/claim", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(payload)

--- a/beta/chill-pepe.html
+++ b/beta/chill-pepe.html
@@ -8,6 +8,7 @@
     <meta property="og:image" content="https://oaidalleapiprodscus.blob.core.windows.net/private/org-uhsM3TYEzcdSzxVlMcJvWVLc/user-zhodxV6oh21CHK1l5bjJMX8f/img-9kpEWg8uDlHcOvLJop1NmLfk.png?st=2025-06-03T12%3A37%3A15Z&se=2025-06-03T14%3A37%3A15Z&sp=r&sv=2024-08-04&sr=b&rscd=inline&rsct=image/png&skoid=cc612491-d948-4d2e-9821-2683df3719f5&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2025-06-02T19%3A19%3A19Z&ske=2025-06-03T19%3A19%3A19Z&sks=b&skv=2024-08-04&sig=3uit0Uq%2BnloHx5AKxg%2Bi1BhZrVJ0qalJp48WKwWb7hc%3D" />
     <meta property="og:description" content="The chillest frog on the blockchain 🐸🧃" />
     <title>Chill Pepe ($$CHILL)</title>
+    <script src="/env.js"></script>
     <style>
       body {
         margin: 0;
@@ -114,7 +115,7 @@
             signature: Array.from(signedMessage.signature),
           };
 
-          const res = await fetch("http://localhost:3001/claim", {
+          const res = await fetch(window.BASE_URL + "/claim", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(payload)

--- a/beta/doge-to-the-moon-.html
+++ b/beta/doge-to-the-moon-.html
@@ -8,6 +8,7 @@
     <meta property="og:image" content="https://oaidalleapiprodscus.blob.core.windows.net/private/org-uhsM3TYEzcdSzxVlMcJvWVLc/user-zhodxV6oh21CHK1l5bjJMX8f/img-xaAJAtC4Q6qbfJAJbk3GhPtp.png?st=2025-06-03T12%3A07%3A37Z&se=2025-06-03T14%3A07%3A37Z&sp=r&sv=2024-08-04&sr=b&rscd=inline&rsct=image/png&skoid=cc612491-d948-4d2e-9821-2683df3719f5&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2025-06-02T19%3A50%3A05Z&ske=2025-06-03T19%3A50%3A05Z&sks=b&skv=2024-08-04&sig=RlJP6Ic9Jjroe696PSDdWyekCyM8c9Rt1j7SIk1PRG8%3D" />
     <meta property="og:description" content="Doge to the Moon" />
     <title>Doge to the moon  ($DTTM)</title>
+    <script src="/env.js"></script>
     <style>
       body {
         margin: 0;
@@ -114,7 +115,7 @@
             signature: Array.from(signedMessage.signature),
           };
 
-          const res = await fetch("http://localhost:3001/claim", {
+          const res = await fetch(window.BASE_URL + "/claim", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(payload)

--- a/beta/test-2.html
+++ b/beta/test-2.html
@@ -8,6 +8,7 @@
     <meta property="og:image" content="https://oaidalleapiprodscus.blob.core.windows.net/private/org-uhsM3TYEzcdSzxVlMcJvWVLc/user-zhodxV6oh21CHK1l5bjJMX8f/img-ruc6ayrD9V2htYBVu4QRfO6Q.png?st=2025-06-03T13%3A04%3A48Z&se=2025-06-03T15%3A04%3A48Z&sp=r&sv=2024-08-04&sr=b&rscd=inline&rsct=image/png&skoid=cc612491-d948-4d2e-9821-2683df3719f5&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2025-06-02T19%3A16%3A22Z&ske=2025-06-03T19%3A16%3A22Z&sks=b&skv=2024-08-04&sig=ki%2BSFQ3Nd1Atvt8jVc0LnWyCiE6/49E1S8/2xZ6Ax9Y%3D" />
     <meta property="og:description" content="A new memecoin launched from Alpha Hub 🚀" />
     <title>test 2 ($TEST2)</title>
+    <script src="/env.js"></script>
     <style>
       body {
         margin: 0;
@@ -121,7 +122,7 @@
             signature: Array.from(signedMessage.signature),
           };
 
-          const res = await fetch("http://localhost:3001/claim", {
+          const res = await fetch(window.BASE_URL + "/claim", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(payload)

--- a/beta/test.html
+++ b/beta/test.html
@@ -8,6 +8,7 @@
     <meta property="og:image" content="https://oaidalleapiprodscus.blob.core.windows.net/private/org-uhsM3TYEzcdSzxVlMcJvWVLc/user-zhodxV6oh21CHK1l5bjJMX8f/img-EIESaKLlMaQwBURZMhsCuOsp.png?st=2025-06-03T12%3A53%3A07Z&se=2025-06-03T14%3A53%3A07Z&sp=r&sv=2024-08-04&sr=b&rscd=inline&rsct=image/png&skoid=cc612491-d948-4d2e-9821-2683df3719f5&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2025-06-02T20%3A21%3A44Z&ske=2025-06-03T20%3A21%3A44Z&sks=b&skv=2024-08-04&sig=bANm4vUpbZUcoi19Hp7aLaNRnZ14C4LG/W09zdNgomU%3D" />
     <meta property="og:description" content="juste test for the moon " />
     <title>TEST ($TEST)</title>
+    <script src="/env.js"></script>
     <style>
       body {
         margin: 0;
@@ -106,7 +107,7 @@
             message,
             signature: Array.from(signedMessage.signature),
           };
-          const res = await fetch("http://localhost:3001/claim", {
+          const res = await fetch(window.BASE_URL + "/claim", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(payload)

--- a/form.html
+++ b/form.html
@@ -5,6 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Alpha Launchpad</title>
+  <script src="/env.js"></script>
   <style>
     body {
       font-family: 'Segoe UI', sans-serif;
@@ -87,7 +88,7 @@
         description: form.description.value,
       };
 
-      const res = await fetch("http://localhost:3001/launch", {
+      const res = await fetch(window.BASE_URL + "/launch", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(data),

--- a/launcher.html
+++ b/launcher.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title>Alpha Token Launcher</title>
+  <script src="/env.js"></script>
 </head>
 <body style="font-family: sans-serif; padding: 40px; background: #111; color: white;">
   <h1>🚀 Launch a Token</h1>
@@ -34,7 +35,7 @@
         description: form.description.value
       };
 
-      const res = await fetch("http://localhost:3001/launch", {
+      const res = await fetch(window.BASE_URL + "/launch", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(data)


### PR DESCRIPTION
## Summary
- add `BASE_URL` variable in `.env`
- expose `BASE_URL` to frontend through `env.js`
- update server to use environment variable when generating pages
- use `window.BASE_URL` for fetch calls in form, launcher, and token pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686289fcb7688323b01691c36a1417c2