### PR TITLE
Refactor gallery building

### DIFF
--- a/server.js
+++ b/server.js
@@ -19,13 +19,11 @@ app.use(express.json());
 app.use("/beta", express.static("beta")); // Sert les pages générées
 app.use("/public", express.static("public")); // Sert les mini-sites générés
 
-// Route pour afficher la page launchpad avec la liste des tokens
-app.get("/launchpad", (req, res) => {
+function buildGallery({ pageTitle, heading }) {
   const betaDir = path.join(__dirname, "beta");
   const files = fs.readdirSync(betaDir).filter(file => file.endsWith(".html"));
 
   let gallery = "";
-
   for (const file of files) {
     const content = fs.readFileSync(path.join(betaDir, file), "utf8");
 
@@ -48,11 +46,11 @@ app.get("/launchpad", (req, res) => {
     `;
   }
 
-  const html = `
+  return `
     <!DOCTYPE html>
     <html>
     <head>
-      <title>Launchpad - Alpha Hub</title>
+      <title>${pageTitle}</title>
       <style>
         body { background: transparent; color: white; font-family: sans-serif; text-align: center; padding: 20px; }
         h1 { color: #00ffff; }
@@ -64,14 +62,18 @@ app.get("/launchpad", (req, res) => {
       </style>
     </head>
     <body>
-      <h1></h1>
+      <h1>${heading}</h1>
       <div class="grid">
         ${gallery}
       </div>
     </body>
     </html>
   `;
+}
 
+// Route pour afficher la page launchpad avec la liste des tokens
+app.get("/launchpad", (req, res) => {
+  const html = buildGallery({ pageTitle: "Launchpad - Alpha Hub", heading: "" });
   res.send(html);
 });
 
@@ -363,91 +365,10 @@ app.post("/launch", async (req, res) => {
 });
 
 app.get("/explore", (req, res) => {
-  const betaDir = path.join(__dirname, "beta");
-  const files = fs.readdirSync(betaDir).filter(file => file.endsWith(".html"));
-
-  let gallery = "";
-
-  for (const file of files) {
-    const content = fs.readFileSync(path.join(betaDir, file), "utf8");
-
-    const titleMatch = content.match(/<h1>(.*?)<\/h1>/);
-    const imgMatch = content.match(/<img src=\"(.*?)\"/);
-    const descMatch = content.match(/<p>(.*?)<\/p>/);
-
-    const title = titleMatch ? titleMatch[1] : "Unknown";
-    const img = imgMatch ? imgMatch[1] : "";
-    const desc = descMatch ? descMatch[1] : "";
-    const link = `/beta/${file}`;
-
-    gallery += `
-      <div class="card">
-        <img src="${img}" alt="${title}" />
-        <h3>${title}</h3>
-        <p>${desc}</p>
-        <a href="${link}" target="_blank">👀 View</a>
-      </div>
-    `;
-  }
-
-  const html = `
-    <!DOCTYPE html>
-    <html>
-    <head>
-      <title>Explore Memecoins - Alpha Hub</title>
-      <style>
-        body {
-          background: transparent;
-          color: white;
-          font-family: sans-serif;
-          text-align: center;
-          padding: 20px;
-        }
-        h1 {
-          color: #00ffff;
-        }
-        .grid {
-          display: grid;
-          grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-          gap: 20px;
-          margin-top: 40px;
-        }
-        .card {
-          background: #1c1c1e;
-          padding: 20px;
-          border-radius: 10px;
-          box-shadow: 0 4px 12px rgba(0,0,0,0.4);
-        }
-        .card img {
-          width: 100%;
-          max-height: 200px;
-          object-fit: cover;
-          border-radius: 8px;
-        }
-        .card h3 {
-          margin: 10px 0;
-          color: #00ffff;
-        }
-        .card a {
-          display: inline-block;
-          margin-top: 10px;
-          padding: 8px 15px;
-          background: #00ffff;
-          color: black;
-          text-decoration: none;
-          border-radius: 5px;
-        }
-      </style>
-    </head>
-    <body>
-      <h1>🧃 Explore Memecoins launched via Alpha Hub</h1>
-      <div class="grid">
-        ${gallery}
-      </div>
-    </body>
-    </html>
-  `;
-
+  const html = buildGallery({
+    pageTitle: "Explore Memecoins - Alpha Hub",
+    heading: "🧃 Explore Memecoins launched via Alpha Hub",
+  });
   res.send(html);
 });
 


### PR DESCRIPTION
## Summary
- create `buildGallery` helper to generate gallery pages
- reuse helper in `/launchpad` and `/explore`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68628919ba148323a31d5354b2cb1ef0