### PR TITLE
Add token claim route and Solana integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "express": "^5.1.0",
     "node-telegram-bot-api": "^0.66.0",
     "openai": "^4.0.0",
-    "socket.io": "^4.8.1"
+    "socket.io": "^4.8.1",
+    "@solana/web3.js": "^1.95.2",
+    "@solana/spl-token": "^0.3.5",
+    "bs58": "^5.0.0",
+    "tweetnacl": "^1.0.3"
   }
 }

--- a/solanaToken.js
+++ b/solanaToken.js
@@ -1,0 +1,19 @@
+const { Connection, clusterApiUrl, Keypair, PublicKey } = require('@solana/web3.js');
+const { createMint } = require('@solana/spl-token');
+const bs58 = require('bs58');
+
+function loadKeypair() {
+  const secret = process.env.SERVER_PRIVATE_KEY;
+  if (!secret) throw new Error('SERVER_PRIVATE_KEY not set');
+  const secretBytes = bs58.decode(secret);
+  return Keypair.fromSecretKey(secretBytes);
+}
+
+async function createSolanaToken(authority) {
+  const connection = new Connection(clusterApiUrl(process.env.SOLANA_CLUSTER || 'devnet'), 'confirmed');
+  const payer = loadKeypair();
+  const mint = await createMint(connection, payer, authority, null, 9);
+  return mint.toBase58();
+}
+
+module.exports = { createSolanaToken };


### PR DESCRIPTION
## Summary
- add Solana SPL token helper to create a mint
- register new dependencies for solana
- implement `/claim` endpoint verifying Phantom signature and creating the token

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6862f35fe0048323a6773b6adab50437