### PR TITLE
Use SOLANA_RPC_URL env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Launchpad-Alpha
+
+This project powers a token launchpad and related utilities.
+
+## Setup
+
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+2. Create a `.env` file and define the following environment variables:
+   - `SERVER_PRIVATE_KEY` – base58 encoded secret key used by the server to pay transaction fees.
+   - `SOLANA_RPC_URL` – (optional) RPC endpoint for Solana. Defaults to `https://rpc.helius.xyz/?api-key=YOUR_API_KEY` on `mainnet-beta`.
+
+Run the server with:
+```bash
+npm start
+```

--- a/solanaToken.js
+++ b/solanaToken.js
@@ -10,7 +10,9 @@ function loadKeypair() {
 }
 
 async function createSolanaToken(authority) {
-  const connection = new Connection(clusterApiUrl(process.env.SOLANA_CLUSTER || 'devnet'), 'confirmed');
+  const rpcUrl =
+    process.env.SOLANA_RPC_URL || 'https://rpc.helius.xyz/?api-key=YOUR_API_KEY';
+  const connection = new Connection(rpcUrl, 'confirmed');
   const payer = loadKeypair();
   const mint = await createMint(connection, payer, authority, null, 9);
   return mint.toBase58();


### PR DESCRIPTION
## Summary
- mention new environment variables in README
- allow overriding Solana RPC URL in `createSolanaToken`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68631516e3988323aa3a6f51adf94f54