### PR TITLE
Fix claim API URL

### DIFF
--- a/beta/chill-baby.html
+++ b/beta/chill-baby.html
@@ -184,7 +184,7 @@
             message,
             signature: Array.from(signedMessage.signature),
           };
-          const res = await fetch("http://localhost:3001/claim", {
+          const res = await fetch("/claim", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(payload)

--- a/beta/chill-pepe.html
+++ b/beta/chill-pepe.html
@@ -114,7 +114,7 @@
             signature: Array.from(signedMessage.signature),
           };
 
-          const res = await fetch("http://localhost:3001/claim", {
+          const res = await fetch("/claim", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(payload)

--- a/beta/doge-to-the-moon-.html
+++ b/beta/doge-to-the-moon-.html
@@ -114,7 +114,7 @@
             signature: Array.from(signedMessage.signature),
           };
 
-          const res = await fetch("http://localhost:3001/claim", {
+          const res = await fetch("/claim", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(payload)

--- a/beta/test-2.html
+++ b/beta/test-2.html
@@ -121,7 +121,7 @@
             signature: Array.from(signedMessage.signature),
           };
 
-          const res = await fetch("http://localhost:3001/claim", {
+          const res = await fetch("/claim", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(payload)

--- a/beta/test.html
+++ b/beta/test.html
@@ -106,7 +106,7 @@
             message,
             signature: Array.from(signedMessage.signature),
           };
-          const res = await fetch("http://localhost:3001/claim", {
+          const res = await fetch("/claim", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(payload)

--- a/server.js
+++ b/server.js
@@ -265,7 +265,7 @@ function generateStyledHtml({ name, ticker, imageUrl, description, slug }) {
             message,
             signature: Array.from(signedMessage.signature),
           };
-          const res = await fetch("http://localhost:3001/claim", {
+          const res = await fetch("${process.env.API_BASE_URL || ''}/claim", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(payload)


### PR DESCRIPTION
## Summary
- switch claim URL in `generateStyledHtml` to use `API_BASE_URL` env var or a relative path
- regenerate existing pages with the new claim URL

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6863156143d88323b05909f8d98d0daf