### PR TITLE
Add basic Jest tests

### DIFF
--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -1,0 +1,64 @@
+const request = require('supertest');
+const bs58 = require('bs58');
+const nacl = require('tweetnacl');
+
+jest.mock('../imageGenerator', () => ({
+  generateImageFromPrompt: jest.fn().mockResolvedValue('http://example.com/image.png'),
+}));
+
+jest.mock('../generateTokenWebsite', () => ({
+  generateTokenWebsite: jest.fn().mockReturnValue('/public/test/index.html'),
+}));
+
+jest.mock('../telegramBot', () => ({
+  createTokenGroup: jest.fn(),
+}));
+
+jest.mock('../solanaToken', () => ({
+  createSolanaToken: jest.fn().mockResolvedValue('token-address'),
+}));
+
+const app = require('../server');
+
+describe('API endpoints', () => {
+  describe('POST /launch', () => {
+    it('returns success for valid input', async () => {
+      const res = await request(app)
+        .post('/launch')
+        .send({ name: 'My Token', ticker: 'MTK', imagePrompt: 'prompt', description: 'desc' });
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual(expect.objectContaining({ success: true }));
+      expect(res.body.url).toContain('/beta/my-token.html');
+    });
+
+    it('returns error for missing name', async () => {
+      const res = await request(app)
+        .post('/launch')
+        .send({ ticker: 'MTK' });
+      expect(res.statusCode).not.toBe(200);
+    });
+  });
+
+  describe('POST /claim', () => {
+    it('returns success for valid input', async () => {
+      const keyPair = nacl.sign.keyPair();
+      const message = 'claim';
+      const signature = nacl.sign.detached(new TextEncoder().encode(message), keyPair.secretKey);
+      const res = await request(app)
+        .post('/claim')
+        .send({
+          slug: 'my-token',
+          wallet: bs58.encode(keyPair.publicKey),
+          message,
+          signature: Array.from(signature),
+        });
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual({ success: true, token: 'token-address' });
+    });
+
+    it('returns 400 for missing parameters', async () => {
+      const res = await request(app).post('/claim').send({});
+      expect(res.statusCode).toBe(400);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -17,5 +17,9 @@
     "@solana/spl-token": "^0.3.5",
     "bs58": "^5.0.0",
     "tweetnacl": "^1.0.3"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/server.js
+++ b/server.js
@@ -491,6 +491,12 @@ io.on("connection", (socket) => {
   });
 });
 
-server.listen(3001, () => {
-  console.log("✅ Alpha Launchpad server + chat running at http://localhost:3001");
-});
+if (require.main === module) {
+  server.listen(3001, () => {
+    console.log(
+      "✅ Alpha Launchpad server + chat running at http://localhost:3001"
+    );
+  });
+}
+
+module.exports = app;


### PR DESCRIPTION
## Summary
- expose `app` in `server.js` for testing
- configure Jest and Supertest
- add initial tests for `/launch` and `/claim`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686315731c08832380f03f219b8c87a4